### PR TITLE
make websocket reconnect when needed by updating its internal IsConne…

### DIFF
--- a/EwelinkNet/API/WebSocket.cs
+++ b/EwelinkNet/API/WebSocket.cs
@@ -29,6 +29,10 @@ namespace EwelinkNet.API
             websocket = new WebSocketSharp.WebSocket(url);
 
             websocket.OnMessage += Websocket_OnMessage;
+
+            websocket.OnClose += (a, s) => IsConnected = false;
+            websocket.OnError += (a, s) => websocket.Close();
+
             websocket.Connect();
             IsConnected = true;
 

--- a/EwelinkNet/EwelinkNet.cs
+++ b/EwelinkNet/EwelinkNet.cs
@@ -106,11 +106,15 @@ namespace EwelinkNet
             deviceCache = Devices.ToDictionary(x => x.deviceid);
         }
 
+        private void InitializeWebSocket()
+        { 
+            webSocket.OnMessage += handleWebsocketResponse;
+        }
+
         public void OpenWebSocket()
         {
             if (webSocket.IsConnected) return;
             webSocket.Connect(Credentials.at, Devices[0].apikey, Credentials.region);
-            webSocket.OnMessage += handleWebsocketResponse;
         }
 
         private void handleWebsocketResponse(object sender, EventWebsocketMessage e)
@@ -128,7 +132,6 @@ namespace EwelinkNet
         public void CloseWebSocket()
         {
             if (!webSocket.IsConnected) return;
-            webSocket.OnMessage -= handleWebsocketResponse;
             webSocket.Disconnect();
         }
     }


### PR DESCRIPTION
I was experimenting disconnections of the websocket when running the library in a server for a long time, probably due to timeout.
The websocket doesn't recover from that.
I hoocked the events OnClose and OnError to update the internal IsConnected state an therefore be able to use the same client over long periods.